### PR TITLE
Change clonePlane to planeInstance

### DIFF
--- a/ch1/program4.js
+++ b/ch1/program4.js
@@ -9,7 +9,7 @@ plane.blood = 500
 plane.attackLevel = 10
 plane.defenseLevel = 7
 
-var clonePlane = Object.create(plane)
-console.log('blood: ' + clonePlane.blood)
-console.log('attackLevel: ' + clonePlane.attackLevel)
-console.log('defenseLevel: ' + clonePlane.defenseLevel)
+var planeInstance = Object.create(plane)
+console.log('blood: ' + planeInstance.blood)
+console.log('attackLevel: ' + planeInstance.attackLevel)
+console.log('defenseLevel: ' + planeInstance.defenseLevel)


### PR DESCRIPTION
console.log(clonePlane.prototype); // undefined
console.log(Plane.prototype); // Plane {}
console.log(clonePlane instanceof Plane); // true

clonePlane is not clone 
It is Plane's instance
change name
clonePlane -> PlaneInstance

see
MDN
Object.create: https://developer.mozilla.org/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/create

Object.assign:  https://developer.mozilla.org/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/assign